### PR TITLE
R4 (ballot2) typedefinitions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 /dump.rdb
 /specification
 /out
+bom-remove.sh
+package-lock.json

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Launch Program",
+            "program": "${workspaceFolder}/build/src/main.js",
+            "sourceMaps": true,
+            "preLaunchTask": "grunt: build"
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,17 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "type": "grunt",
+            "task": "build",
+            "problemMatcher": []
+        },
+        {
+            "type": "grunt",
+            "task": "execute",
+            "problemMatcher": []
+        }
+    ]
+}

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -12,8 +12,9 @@ module.exports = function(grunt) {
             'download-specification': {
                 options: {
                     allowOverwrite: false,
-                    src: 'http://www.hl7.org/fhir/fhir-spec.zip',
-                    dst: 'specification/fhir-spec.zip'
+//                    src: 'http://www.hl7.org/fhir/fhir-spec.zip',
+                      src: 'http://hl7.org/fhir/2018Sep/fhir-spec.zip',
+                      dst: 'specification/fhir-spec.zip'
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "async": "^1.2.1",
     "change-case": "^2.3.0",
     "glob": "^5.0.10",
+    "grunt-if-missing": "^1.0.1",
     "mkdirp": "^0.5.1"
   }
 }

--- a/src/emitters/declartionEmitter.ts
+++ b/src/emitters/declartionEmitter.ts
@@ -17,16 +17,18 @@ function emitFiles(outDir: string, types: Type[]): EmitResults {
     var writer = new Writer(path.join(outDir, "fhir.d.ts"));
 
     // Write the header
-    writer.write("// Type definitions for FHIR Release 3 (STU)");
+    writer.write("// Type definitions for FHIR Release 4 (3.5.0 ballot)");
     writer.writeLine();
     writer.write("// Project: http://hl7.org/fhir/index.html");
     writer.writeLine();
-    writer.write("// Definitions by: Artifact Health <https://www.artifacthealth.com>");
+    writer.write("// Definitions by FHIR STU Release 3: Artifact Health <https://www.artifacthealth.com>");
     writer.writeLine();
     writer.write("// Definitions: https://github.com/borisyankov/DefinitelyTyped");
     writer.writeLine();
+    writer.write("// Definitions adapted for R4 by Oliver/Ahdis");
     writer.writeLine();
-    writer.write("declare module fhir {");
+    writer.writeLine();
+    writer.write("declare module fhir.r4 {");
     writer.writeLine();
     writer.increaseIndent();
 

--- a/src/reader.ts
+++ b/src/reader.ts
@@ -59,26 +59,35 @@ export function readSpecification(basePath: string): CreateFileMapResults {
 
     function processFile(filename: string, content: any): void {
 
-        if(!content) return;
+//        console.log("processFile " + filename + " - " + content);
+
+        if (!content) return;
 
         // only process value sets and structure definitions
         if(content.resourceType != "ValueSet" && content.resourceType != "StructureDefinition" && content.resourceType != "CodeSystem") {
+//            console.log("skipping because no vs, sd or cs "+filename)
             return;
         }
 
         // skip files that are of resource type StructureDefinition but do not contain '.profile' in their name
         if(content.resourceType == "StructureDefinition" && filename.indexOf(".profile") == -1) {
+  //          console.log("skipping because no vad and no .profile "+filename)
             return;
         }
 
         // skip files that do not define an id
         var id = getContentId(content);
-        if(!id) return;
+        if(!id) {
+  //          console.log("skipping beaus no id "+filename)
+            return;
+        }
 
         if(result.files[id]) {
             addError("Duplicate id '%s' already defined in file '%s'.", id, result.files[id].filename);
             return;
         }
+
+  //      console.log("addidng"+filename+" id "+id);
 
         result.files[id] = {
             id,

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,11 +1,70 @@
-/// <reference path="../typings/fhir.d.ts" />
-
 interface Callback {
     (err?: Error): void;
 }
 
 interface ResultCallback<T> {
     (err?: Error, result?: T): void;
+}
+
+interface ResourceBase {
+    /**
+     * The type of the resource.
+     */
+    resourceType?: string;
+    /**
+     * Contains extended information for property 'resourceType'.
+     */
+    _resourceType?: Element;
+    /**
+     * Logical id of this artifact
+     */
+    id?: string;
+    /**
+     * Contains extended information for property 'id'.
+     */
+    _id?: Element;
+    /**
+     * Metadata about the resource
+     */
+ //   meta?: Meta;
+    /**
+     * A set of rules under which this content was created
+     */
+//    implicitRules?: uri;
+    /**
+     * Contains extended information for property 'implicitRules'.
+     */
+ //   _implicitRules?: Element;
+    /**
+     * Language of the resource content
+     */
+ //   language?: code;
+    /**
+     * Contains extended information for property 'language'.
+     */
+ //   _language?: Element;
+}
+
+/**
+  * A resource with narrative, extensions, and contained resources
+  */
+interface DomainResource extends ResourceBase {
+    /**
+     * Text summary of the resource, for human interpretation
+     */
+//    text?: Narrative;
+    /**
+     * Contained, inline Resources
+     */
+//    contained?: Resource[];
+    /**
+     * Additional Content defined by implementations
+     */
+//    extension?: Extension[];
+    /**
+     * Extensions that cannot be ignored
+     */
+//    modifierExtension?: Extension[];
 }
 
 interface SpecificationFile {
@@ -17,7 +76,7 @@ interface SpecificationFile {
     referenced?: boolean;
 
     symbol?: string;
-    content?: fhir.DomainResource;
+    content?: DomainResource;
     type?: Type;
 }
 


### PR DESCRIPTION
I tried to adapt the typedefinitions for R4 ballot and encountered the following issues which I worked around:

- for the current build there is no fhir-spec.zip, i used now the 2nd R4 ballot
- the r4 ballot zip contained in some json files a bom, I had to remove them that the files could be read 
- I needed to add new types which came for R4
- type.d.ts referenced the generated fhir.d.ts, I extracted the "hopefully normative" base parts to type.d.ts that it can be fhir version independent
- in the processing part I could not figure out why valueset/codesystems are processed, I ommitted them for now, and I needed to adjust issues around extension and SimpleQuantity.

I could create a type definition (https://github.com/ahdis/ng-fhir-sample/blob/master/src/fhir.r4/index.d.ts), but could not manage to add the tests. If you can take something from my work over, I'm happy to assist.

Two open questions:

- The specifications contain also explicit json profile definitions (http://hl7.org/fhir/definitions.json.zip), did you try these one outs or excluded them for a specific reason? 
- Did you evaluate to transform the json schemas to typescript (http://hl7.org/fhir/fhir.schema.json.zip)? 